### PR TITLE
Feature - VisualRenderObsWrapper (#2)

### DIFF
--- a/CHANGELOG_CEAI.md
+++ b/CHANGELOG_CEAI.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [PR#2](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/2) Changing the env observation to the rgb_array type with VisualRenderObsWrapper.
 - [PR#1](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/1) Tracking with MLflow.
 - [PR#1](https://github.com/AGH-CEAI/rl-baselines3-zoo/pull/1) Logging git repositories hashes and preventing uncommitted changes.
   

--- a/rl_zoo3/tracking/tracking_backend.py
+++ b/rl_zoo3/tracking/tracking_backend.py
@@ -93,9 +93,7 @@ class TrackingBackend(ABC):
 
     def log_params(self, params: Dict | Any) -> None:
         if not self.is_initalized():
-            logger.warning(
-                f"WARNING: Tried to log paramaters without initialization of the tracking backend! Call ignored."
-            )
+            logger.warning(f"WARNING: Tried to log paramaters without initialization of the tracking backend! Call ignored.")
             return
 
         params_dict = params
@@ -106,9 +104,7 @@ class TrackingBackend(ABC):
 
     def log_directory(self, local_dir: str, artifacts_dir: str = None) -> None:
         if not self.is_initalized():
-            logger.warning(
-                f"WARNING: Tried to log directory without initialization of the tracking backend! Call ignored."
-            )
+            logger.warning(f"WARNING: Tried to log directory without initialization of the tracking backend! Call ignored.")
             return
         self._log_directory(local_dir=local_dir, artifacts_dir=artifacts_dir)
 


### PR DESCRIPTION
Wrapper for passing rendered rgb_array frame as observation

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
